### PR TITLE
Signup backend

### DIFF
--- a/force-app/main/default/classes/MentorUserController.cls
+++ b/force-app/main/default/classes/MentorUserController.cls
@@ -1,0 +1,9 @@
+public with sharing class MentorUserController {
+    @AuraEnabled
+    public static void saveUserRecord(MentorAmp_User__c user) {
+        System.debug('User: ' + 'user => '+JSON.serialize(user));
+        if(user != null){
+            insert user;
+        } 
+    }
+}

--- a/force-app/main/default/classes/MentorUserController.cls
+++ b/force-app/main/default/classes/MentorUserController.cls
@@ -1,7 +1,6 @@
 public with sharing class MentorUserController {
     @AuraEnabled
     public static void saveUserRecord(MentorAmp_User__c user) {
-        System.debug('User: ' + 'user => '+JSON.serialize(user));
         if(user != null){
             insert user;
         } 

--- a/force-app/main/default/classes/MentorUserController.cls-meta.xml
+++ b/force-app/main/default/classes/MentorUserController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/RecordTypeController.cls
+++ b/force-app/main/default/classes/RecordTypeController.cls
@@ -1,0 +1,15 @@
+public with sharing class RecordTypeController {
+    @AuraEnabled(cacheable=true)
+    public static Id getMentorRecordType() {
+        Id recordTypeId = Schema.SObjectType.MentorAmp_User__c.getRecordTypeInfosByDeveloperName().get('Mentor').getRecordTypeId();
+        System.debug(''+recordTypeId);
+        return recordTypeId;
+    }
+    
+    @AuraEnabled(cacheable=true)
+    public static Id getMenteeRecordType() {
+        Id recordTypeId = Schema.SObjectType.MentorAmp_User__c.getRecordTypeInfosByDeveloperName().get('Mentee').getRecordTypeId();
+        System.debug(''+recordTypeId);
+        return recordTypeId;
+    }
+}

--- a/force-app/main/default/classes/RecordTypeController.cls
+++ b/force-app/main/default/classes/RecordTypeController.cls
@@ -2,14 +2,12 @@ public with sharing class RecordTypeController {
     @AuraEnabled(cacheable=true)
     public static Id getMentorRecordType() {
         Id recordTypeId = Schema.SObjectType.MentorAmp_User__c.getRecordTypeInfosByDeveloperName().get('Mentor').getRecordTypeId();
-        System.debug(''+recordTypeId);
         return recordTypeId;
     }
     
     @AuraEnabled(cacheable=true)
     public static Id getMenteeRecordType() {
         Id recordTypeId = Schema.SObjectType.MentorAmp_User__c.getRecordTypeInfosByDeveloperName().get('Mentee').getRecordTypeId();
-        System.debug(''+recordTypeId);
         return recordTypeId;
     }
 }

--- a/force-app/main/default/classes/RecordTypeController.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/userInfoController.cls
+++ b/force-app/main/default/classes/userInfoController.cls
@@ -3,7 +3,6 @@ public with sharing class userInfoController {
     public static User getUserInfo() {
     
         User currentUser = [Select Id, Name, Email, MobilePhone from User where Id=:UserInfo.getUserId()];
-        System.debug('currentUser: ' + currentUser);
         return currentUser;
     }
 }

--- a/force-app/main/default/classes/userInfoController.cls
+++ b/force-app/main/default/classes/userInfoController.cls
@@ -1,0 +1,9 @@
+public with sharing class userInfoController {
+    @AuraEnabled(cacheable=true)
+    public static User getUserInfo() {
+    
+        User currentUser = [Select Id, Name, Email, MobilePhone from User where Id=:UserInfo.getUserId()];
+        System.debug('currentUser: ' + currentUser);
+        return currentUser;
+    }
+}

--- a/force-app/main/default/classes/userInfoController.cls-meta.xml
+++ b/force-app/main/default/classes/userInfoController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/main/main.html
+++ b/force-app/main/default/lwc/main/main.html
@@ -1,9 +1,4 @@
 <template>
-    <p>Hello Main</p>
-    <template if:true={isModalOpen}>
-        <c-signup></c-signup>
-    </template>
-  
     <c-progress-tracker onrefresh={refreshCategories}></c-progress-tracker>
     <c-signup onrefresh={refreshView}></c-signup>
 

--- a/force-app/main/default/lwc/main/main.html
+++ b/force-app/main/default/lwc/main/main.html
@@ -1,4 +1,6 @@
 <template>
     <p>Hello Main</p>
-    <c-signup></c-signup>
+    <template if:true={isModalOpen}>
+        <c-signup></c-signup>
+    </template>
 </template>

--- a/force-app/main/default/lwc/main/main.html
+++ b/force-app/main/default/lwc/main/main.html
@@ -1,3 +1,4 @@
 <template>
     <p>Hello Main</p>
+    <c-signup></c-signup>
 </template>

--- a/force-app/main/default/lwc/main/main.js
+++ b/force-app/main/default/lwc/main/main.js
@@ -7,8 +7,6 @@ import getCategories from '@salesforce/apex/mainComponentController.getCategorie
 import getCurrentWeek from '@salesforce/apex/mainComponentController.getCurrentWeek';
 import updateCurrentWeek from '@salesforce/apex/mainComponentController.updateCurrentWeek';
 
-export default class Main extends LightningElement {
-
 const COLS1 = [
     { label: 'Category', fieldName: 'Name', hideDefaultActions: true, wrapText: true },
     { label: 'Weekly Goal', fieldName: 'mtAmp__Weekly_Goal__c', hideDefaultActions: true, wrapText: true },

--- a/force-app/main/default/lwc/main/main.js
+++ b/force-app/main/default/lwc/main/main.js
@@ -1,4 +1,3 @@
-import { LightningElement } from "lwc";
 import { LightningElement, wire } from 'lwc';
 import { refreshApex } from '@salesforce/apex';
 import getMentorAmpUser from '@salesforce/apex/mainComponentController.getMentorAmpUser';
@@ -9,9 +8,6 @@ import getCurrentWeek from '@salesforce/apex/mainComponentController.getCurrentW
 import updateCurrentWeek from '@salesforce/apex/mainComponentController.updateCurrentWeek';
 
 export default class Main extends LightningElement {
-    openSignup () {
-        this.template.querySelector("c-signup").openModal();
-    }
 
 const COLS1 = [
     { label: 'Category', fieldName: 'Name', hideDefaultActions: true, wrapText: true },

--- a/force-app/main/default/lwc/main/main.js
+++ b/force-app/main/default/lwc/main/main.js
@@ -1,4 +1,7 @@
-import { LightningElement } from 'lwc';
+import { LightningElement } from "lwc";
 
 export default class Main extends LightningElement {
+    openSignup () {
+        this.template.querySelector("c-signup").openModal();
+    }
 }

--- a/force-app/main/default/lwc/signup/signup.html
+++ b/force-app/main/default/lwc/signup/signup.html
@@ -6,6 +6,21 @@
 	<!--Use template if:true to display/hide popup based on isModalOpen value-->
 	<template if:true={isModalOpen}>
 		<!-- Modal/Popup Box LWC starts here -->
+		<template if:true={isSavedSuccess}>
+			<lightning-card title="Signup" icon-name="custom:custom19">
+				<div class="slds-m-around_medium">
+					<lightning-input label="Title" value={_title} onchange={titleChange}></lightning-input>
+					<lightning-input label="Message" value={message} onchange={messageChange}></lightning-input>
+					<lightning-combobox
+						label="Variant"
+						value={variant}
+						onchange={variantChange}
+						options={variantOptions}>
+					</lightning-combobox>
+					<p class="slds-m-vertical_small"><lightning-button label="Show Notification" onclick={showNotification}></lightning-button></p>
+				</div>
+			</lightning-card>
+		</template>
 		<section role="dialog" tabindex="-1" aria-labelledby="modal-heading-01" aria-modal="true" aria-describedby="modal-content-id-1" class="slds-modal slds-fade-in-open">
 			<div class="slds-modal__container">
 				<!-- Modal/Popup Box LWC header here -->
@@ -35,17 +50,24 @@
 				</div>
 				<!-- Step 2 - Personal Data -->
 				<div class="stepTwo slds-hide">
-					<div class="slds-modal__content slds-p-around_medium" id="modal-content-id-2">
-						<div class="lgc-bg">
-							<lightning-input type="text" label="Name"></lightning-input>
+					<template if:true={user}>
+						<div class="slds-modal__content slds-p-around_medium" id="modal-content-id-2" >
+							<div class="lgc-bg">
+								<lightning-input type="text" label="Name" value={userName} onchange={nameChange}></lightning-input>
+							</div>
+							<div class="lgc-bg">
+								<lightning-input type="text" label="E-mail" value={userEmail} onchange={emailChange}></lightning-input>
+							</div>
+							<div class="lgc-bg">
+								<lightning-input type="text" label="Phone" value={userMobile} onchange={mobileChange}></lightning-input>
+							</div>
 						</div>
-						<div class="lgc-bg">
-							<lightning-input type="text" label="E-mail"></lightning-input>
-						</div>
-						<div class="lgc-bg">
-							<lightning-input type="text" label="Phone"></lightning-input>
-						</div>
-					</div>
+						</template>
+						<template if:false={user}>
+							<div>
+								<h1>No UserInfo available</h1>
+							</div>
+						</template>
 					<footer class="slds-modal__footer">
 						<button class="slds-button slds-button_neutral slds-float_left" onclick={closeModal} title="Cancel">Cancel</button>
 						<lightning-button class="slds-m-top_small" label="Previous" onclick={goBackToStepOne}></lightning-button>

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -118,7 +118,7 @@ export default class ModalPopupLWC extends LightningElement {
         user.Name__c= this.userName;
         user.Email__c = this.userEmail;
         user.Phone__c = this.userMobile;
-        user.Id = this.userId;
+        user.User__c = this.userId;
         if (this.isMentor) {
             user.RecordTypeId = this.mentorRecordTypeId;
         } else {

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -104,6 +104,7 @@ export default class ModalPopupLWC extends LightningElement {
             // Clear the user enter values
             this.user = {};   
             this.showNotification("Signup", "Successfully signed up!", 'success');
+            this.isSavedSuccess = true;   
         })
         .catch(error => {
             this.showNotification("Signup", error.message, "error");
@@ -181,8 +182,7 @@ export default class ModalPopupLWC extends LightningElement {
             message: message,
             variant: variant,
         });
-        this.isSavedSuccess = true;   
-
+        
         this.dispatchEvent(evt);
     }
 }

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -43,6 +43,7 @@ export default class ModalPopupLWC extends LightningElement {
             this.userName = data.Name;
             this.userEmail = data.Email;
             this.userMobile = data.MobilePhone;
+            this.userId = data.Id;
             this.error = undefined;
         }
         else if (error) {

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -1,8 +1,28 @@
-import { LightningElement,track } from 'lwc';
+import { LightningElement, track, api, wire } from "lwc";
+import { getRecord } from 'lightning/uiRecordApi';
+import getUserInfo from '@salesforce/apex/userInfoController.getUserInfo';
+
+// import MentorAmp_User from '@salesforce/schema/MentorAmp_User__c';
+// import Name from '@salesforce/schema/MentorAmp_User.Name__c';
+
+import USER_OBJECT from '@salesforce/schema/User';
 
 export default class ModalPopupLWC extends LightningElement {
-    @track isModalOpen = false;
+    @track isModalOpen = true;
     @track currentStep;
+
+    @wire(getUserInfo)
+    wiredUser({data, error}){
+        console.log('wiredUser: ', this.wiredUser);
+        if(data){
+            this.user = data;
+            this.error = undefined;
+        }
+        else if (error) {
+            this.error = error;
+            this.user = undefined;
+        }
+    }
     isMentor;
     _selected = [];
 
@@ -35,6 +55,7 @@ export default class ModalPopupLWC extends LightningElement {
         return this._selected.length ? this._selected : 'none';
     }
 
+    @api
     openModal() {
         // to open modal set isModalOpen tarck value as true
         this.isModalOpen = true;
@@ -63,7 +84,8 @@ export default class ModalPopupLWC extends LightningElement {
         this.currentStep = '2';
         this.isMentor = false;
         this.template.querySelector('div.stepOne').classList.add('slds-hide');
-        this.template.querySelector('div.stepTwo').classList.remove('slds-hide');
+        this.template.querySelector('div.stepTwo').classList.remove('slds-hide'); 
+        console.log('userInfo: ', this.wiredUser());   
     }
 
     goToStepTwoMentor() {
@@ -88,4 +110,5 @@ export default class ModalPopupLWC extends LightningElement {
     handleChange(e) {
         this._selected = e.detail.value;
     }
+
 }

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -118,6 +118,7 @@ export default class ModalPopupLWC extends LightningElement {
         user.Name__c= this.userName;
         user.Email__c = this.userEmail;
         user.Phone__c = this.userMobile;
+        user.Id = this.userId;
         if (this.isMentor) {
             user.RecordTypeId = this.mentorRecordTypeId;
         } else {

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -3,8 +3,6 @@ import { getRecord } from 'lightning/uiRecordApi';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 import getUserInfo from '@salesforce/apex/userInfoController.getUserInfo';
 import saveUserRecord from '@salesforce/apex/MentorUserController.saveUserRecord';
-import getMenteeRecordType from '@salesforce/apex/RecordTypeController.getMenteeRecordType';
-import getMentorRecordType from '@salesforce/apex/RecordTypeController.getMentorRecordType';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
 import MentorUser_OBJECT from '@salesforce/schema/MentorAmp_User__c';

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -1,4 +1,3 @@
-
 import { LightningElement, track, api, wire } from "lwc";
 import { getRecord } from 'lightning/uiRecordApi';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
@@ -10,18 +9,17 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
 import MentorUser_OBJECT from '@salesforce/schema/MentorAmp_User__c';
 
-import { LightningElement, track, api } from 'lwc';
-import { ShowToastEvent } from 'lightning/platformShowToastEvent';
-
 export default class ModalPopupLWC extends LightningElement {
-    @track isModalOpen = true;
-    @track currentStep;
-    @track userName;
-    @track userEmail;
-    @track userMobile; 
-    @track menteeRecordTypeId;
-    @track mentorRecordTypeId;
-    @track isSavedSuccess = true;
+    isModalOpen = false;
+    currentStep;
+    userName;
+    userEmail;
+    userMobile; 
+    menteeRecordTypeId;
+    mentorRecordTypeId;
+    isSavedSuccess = true;
+    isMentor;
+    _selected = [];
 
     @wire(getObjectInfo, {objectApiName: MentorUser_OBJECT})
     getRecordTypeId({data, error}){
@@ -35,7 +33,7 @@ export default class ModalPopupLWC extends LightningElement {
                     this.menteeRecordTypeId = value.recordTypeId;
                 }
             }
-        }else if(error){
+        } else if(error){
             this.showNotification("Signup", error.message, "error");
          }
       };
@@ -55,8 +53,6 @@ export default class ModalPopupLWC extends LightningElement {
             this.showNotification("Signup", error.message, "error");
         }
     }
-    isMentor;
-    _selected = [];
 
     get options() {
         return [


### PR DESCRIPTION
## Add backend logic to the Signup Component

**This PR addresses the Asana Task:** [Add backend logic to the Signup Component](<https://app.asana.com/0/1200052110995462/1199873427042143/f>)

### Features of this PR

1. Display the signup modal and asks whether user is mentor or mentee,
2. Displays the signup modal with current Salesforce user's name, email and phone in user info modal.
3. Displays the list of skills.
4. Creates a new MentorAmp_User record with recordtypeId matching either mentor or mentee type and saves the user info -- except for skills.
5. Displays successfully signed up message and dismisses all modals

Then provide an organized and clear summary of the changes you've made to achieve this.

**You can use bullet points to describe your changes**
- Added new classes to: 

1. Determine recordTypeId 
2. Get current logged in user's info  (name, email, phone) to display in user signup modal
3. Save user info to MentorAmp_user record with recordTypeId from 1

### Steps to Verify and Test Changes
Please describe the tests that you've performed to verify your changes. Provide instruction steps to reproduce the changes.
- [X] Launched Signup with temporary signup button 
- [X] Verified that correct user info displayed in user modal
- [X] Verified that record was saved correctly when Save button was clicked


### Checklist:
Please insert an X inside the brackets to check off each item. All items are to be completed.

- [X] I have performed a self-review of my own code
- [x] I have commented my code appropriately, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added necessary unit tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


### Before Screenshots
n/a

### After Screenshots
![image](https://user-images.githubusercontent.com/72955443/115137995-425ed780-9fde-11eb-98fe-efa6062734cd.png)

![image](https://user-images.githubusercontent.com/72955443/115138008-599dc500-9fde-11eb-951f-b7da6743fab4.png)

![image](https://user-images.githubusercontent.com/72955443/115138019-6d492b80-9fde-11eb-93db-41226e5b7871.png)

<img width="1366" alt="Screen Shot 2021-04-18 at 12 42 00 AM" src="https://user-images.githubusercontent.com/72955443/115138121-198b1200-9fdf-11eb-9cbf-3071818be178.png">





