### PR TITLE
Small fixes for the signup flow

### DIFF
--- a/force-app/main/default/classes/MentorUserController.cls
+++ b/force-app/main/default/classes/MentorUserController.cls
@@ -1,7 +1,13 @@
 public with sharing class MentorUserController {
     @AuraEnabled
     public static void saveUserRecord(MentorAmp_User__c user) {
+        Id menteeRecordTypeId = Schema.SObjectType.MentorAmp_User__c.getRecordTypeInfosByName().get('Mentee').getRecordTypeId();
         if(user != null){
+            if (user.RecordTypeId == menteeRecordTypeId) {
+                Progress_Tracker__c pgTrack = new Progress_Tracker__c();
+                insert pgTrack;
+                user.Progress_Tracker__c = pgTrack.Id;
+            }
             insert user;
         } 
     }

--- a/force-app/main/default/lwc/main/main.js
+++ b/force-app/main/default/lwc/main/main.js
@@ -209,6 +209,10 @@ export default class Main extends LightningElement {
         this.template.querySelector('c-progress-tracker').openTrackerAsMentor();
     }
 
+    signupAsMentee () {
+        this.template.querySelector('c-signup').openModal();
+    }
+
     signupAsMentor () {
         this.template.querySelector('c-signup').openModal();
     }

--- a/force-app/main/default/lwc/signup/signup.js
+++ b/force-app/main/default/lwc/signup/signup.js
@@ -126,6 +126,7 @@ export default class ModalPopupLWC extends LightningElement {
         }
         this.saveRecord(user);
         this.closeModal();
+        this.dispatchEvent(new CustomEvent('refresh'));
     }
 
     goBackToStepOne() {
@@ -138,7 +139,7 @@ export default class ModalPopupLWC extends LightningElement {
         this.currentStep = '2';
         this.isMentor = false;
         this.template.querySelector('div.stepOne').classList.add('slds-hide');
-        this.template.querySelector('div.stepTwo').classList.remove('slds-hide'); 
+        this.template.querySelector('div.stepTwo').classList.remove('slds-hide');
     }
 
     goToStepTwoMentor() {


### PR DESCRIPTION
Fix 1:
Create a Progress Tracker for the newly signed up mentee (but not for mentor).

Fix 2:
Fix "Sign Up as a Mentee" button to open the signup window

Fix 3:
Refresh the page to refresh he main component after user signed up either as a mentor or mentee.